### PR TITLE
Implement glass material and realistic colors for hourglass

### DIFF
--- a/src/mesh_hourglass.rs
+++ b/src/mesh_hourglass.rs
@@ -3,6 +3,7 @@
 use bevy::{
     prelude::*,
     render::{mesh::Indices, render_resource::PrimitiveTopology},
+    sprite::AlphaMode2d,
 };
 use earcutr::earcut;
 
@@ -31,7 +32,7 @@ impl Default for HourglassMeshBodyConfig {
             neck_width: 12.0,
             neck_height: 7.0,
             neck_curve_resolution: 5,
-            color: Color::srgb(0.8, 0.5, 0.3),
+            color: Color::srgba(0.85, 0.95, 1.0, 0.6), // Light blue glass with transparency
         }
     }
 }
@@ -49,7 +50,7 @@ impl Default for HourglassMeshPlatesConfig {
         Self {
             width: 165.0,
             height: 10.0,
-            color: Color::srgb(0.0, 0.0, 0.0),
+            color: Color::srgb(0.6, 0.4, 0.2), // Wood brown color
         }
     }
 }
@@ -309,11 +310,18 @@ impl HourglassMeshBuilder {
         mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
         mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
 
+        // Create glass material with transparency
+        let glass_material = materials.add(ColorMaterial {
+            color: config.color,
+            alpha_mode: AlphaMode2d::Blend,
+            ..default()
+        });
+
         commands
             .spawn((
                 HourglassMeshBody,
                 Mesh2d(meshes.add(mesh)),
-                MeshMaterial2d(materials.add(config.color)),
+                MeshMaterial2d(glass_material),
             ))
             .id()
     }


### PR DESCRIPTION
This PR implements glass materials with transparency and improves the default colors to make the hourglass look more realistic.

## Changes
- Add transparent glass material using AlphaMode2d::Blend
- Set default body color to light blue glass (srgba 0.85, 0.95, 1.0, 0.6)
- Set default plate color to wood brown (srgb 0.6, 0.4, 0.2)
- Import AlphaMode2d from bevy::sprite for transparency support

Fixes #14

Generated with [Claude Code](https://claude.ai/code)