### PR TITLE
feat: add optional sand splash animation for hourglasses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 bevy = "0.16.0"
 earcutr = "0.4"
+rand = "0.8"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"

--- a/examples/sand_splash_demo.rs
+++ b/examples/sand_splash_demo.rs
@@ -1,0 +1,102 @@
+//! Demonstrates the sand splash animation feature.
+//!
+//! This example showcases how to configure and use the optional sand splash animation
+//! that creates particles around where sand hits the bottom of the hourglass.
+
+use bevy::prelude::*;
+use bevy_hourglass::{
+    components::SandSplashConfig, 
+    spawn_mesh_hourglass_with_timer, 
+    HourglassMeshBuilder, 
+    HourglassMeshBodyConfig, 
+    HourglassMeshPlatesConfig, 
+    HourglassMeshSandConfig, 
+    HourglassPlugin
+};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(HourglassPlugin)
+        .add_systems(Startup, setup)
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+) {
+    // Spawn camera
+    commands.spawn(Camera2d);
+
+    // Basic hourglass without sand splash (for comparison)
+    spawn_mesh_hourglass_with_timer(
+        &mut commands,
+        &mut meshes,
+        &mut materials,
+        10.0, // 10 seconds
+        Vec3::new(-300.0, 0.0, 0.0),
+    );
+
+    // Spawn text label for basic hourglass
+    commands.spawn((
+        Text::new("Basic\n(No Splash)"),
+        TextLayout::new_with_justify(JustifyText::Center),
+        Transform::from_translation(Vec3::new(-300.0, -150.0, 0.0)),
+    ));
+
+    // Hourglass with default sand splash
+    let default_splash_config = SandSplashConfig {
+        enabled: true,
+        ..Default::default()
+    };
+
+    HourglassMeshBuilder::new(Transform::from_translation(Vec3::new(0.0, 0.0, 0.0)))
+        .with_body(HourglassMeshBodyConfig::default())
+        .with_plates(HourglassMeshPlatesConfig::default())
+        .with_sand(HourglassMeshSandConfig::default())
+        .with_sand_splash(default_splash_config)
+        .with_timing(10.0)
+        .build(&mut commands, &mut meshes, &mut materials);
+
+    // Spawn text label for default splash
+    commands.spawn((
+        Text::new("Default Splash"),
+        TextLayout::new_with_justify(JustifyText::Center),
+        Transform::from_translation(Vec3::new(0.0, -150.0, 0.0)),
+    ));
+
+    // Hourglass with custom sand splash configuration
+    let custom_splash_config = SandSplashConfig {
+        enabled: true,
+        splash_radius: 35.0,
+        particle_count: 12,
+        particle_duration: 0.8,
+        spawn_interval: 0.05,
+        particle_color: Color::srgb(1.0, 0.4, 0.1), // Bright orange
+        particle_size: 3.0,
+    };
+
+    HourglassMeshBuilder::new(Transform::from_translation(Vec3::new(300.0, 0.0, 0.0)))
+        .with_body(HourglassMeshBodyConfig::default())
+        .with_plates(HourglassMeshPlatesConfig::default())
+        .with_sand(HourglassMeshSandConfig::default())
+        .with_sand_splash(custom_splash_config)
+        .with_timing(10.0)
+        .build(&mut commands, &mut meshes, &mut materials);
+
+    // Spawn text label for custom splash
+    commands.spawn((
+        Text::new("Custom Splash\n(Orange, Larger)"),
+        TextLayout::new_with_justify(JustifyText::Center),
+        Transform::from_translation(Vec3::new(300.0, -150.0, 0.0)),
+    ));
+
+    // Instructions
+    commands.spawn((
+        Text::new("Sand Splash Demo\nWatch the particles appear where sand hits the bottom!"),
+        TextLayout::new_with_justify(JustifyText::Center),
+        Transform::from_translation(Vec3::new(0.0, 250.0, 0.0)),
+    ));
+}

--- a/src/components.rs
+++ b/src/components.rs
@@ -78,6 +78,66 @@ impl Default for Hourglass {
     }
 }
 
+/// Configuration for sand splash animation
+#[derive(Debug, Clone)]
+pub struct SandSplashConfig {
+    /// Whether sand splash is enabled
+    pub enabled: bool,
+    /// Radius around impact point where sand particles appear
+    pub splash_radius: f32,
+    /// Number of splash particles to spawn
+    pub particle_count: u32,
+    /// Duration each splash particle stays visible (in seconds)
+    pub particle_duration: f32,
+    /// How often to spawn new splash particles (in seconds)
+    pub spawn_interval: f32,
+    /// Color of splash particles
+    pub particle_color: Color,
+    /// Size of each splash particle
+    pub particle_size: f32,
+}
+
+impl Default for SandSplashConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            splash_radius: 20.0,
+            particle_count: 8,
+            particle_duration: 0.5,
+            spawn_interval: 0.1,
+            particle_color: Color::srgb(0.8, 0.6, 0.2),
+            particle_size: 2.0,
+        }
+    }
+}
+
+/// Component that tracks sand splash state for an hourglass
+#[derive(Component, Debug, Clone)]
+pub struct SandSplash {
+    pub config: SandSplashConfig,
+    /// Timer for spawning new splash particles
+    pub spawn_timer: f32,
+    /// Track if sand was flowing in the previous frame (to detect start of impact)
+    pub was_flowing: bool,
+}
+
+impl SandSplash {
+    pub fn new(config: SandSplashConfig) -> Self {
+        Self {
+            config,
+            spawn_timer: 0.0,
+            was_flowing: false,
+        }
+    }
+}
+
+/// Marker component for sand splash particles
+#[derive(Component, Debug)]
+pub struct SandSplashParticle {
+    /// Time remaining before particle disappears
+    pub lifetime: f32,
+}
+
 impl Hourglass {
     /// Create a new hourglass with the specified total time in seconds
     pub fn new(total_time: f32) -> Self {

--- a/src/mesh_hourglass.rs
+++ b/src/mesh_hourglass.rs
@@ -1,6 +1,6 @@
 //! Mesh-based hourglass implementation with composable parts.
 
-use crate::components::Hourglass;
+use crate::components::{Hourglass, SandSplash, SandSplashConfig};
 use crate::curves::{generate_sand_outline, BulbStyle, HourglassShapeBuilder, NeckStyle, SandBulb};
 use bevy::{
     prelude::*,
@@ -124,6 +124,7 @@ pub struct HourglassMeshBuilder {
     body_config: Option<HourglassMeshBodyConfig>,
     plates_config: Option<HourglassMeshPlatesConfig>,
     sand_config: Option<HourglassMeshSandConfig>,
+    sand_splash_config: Option<SandSplashConfig>,
     timing: Option<f32>,
     flip_duration: Option<f32>,
     auto_flip: Option<bool>,
@@ -137,6 +138,7 @@ impl HourglassMeshBuilder {
             body_config: None,
             plates_config: None,
             sand_config: None,
+            sand_splash_config: None,
             timing: None,
             flip_duration: None,
             auto_flip: None,
@@ -179,6 +181,12 @@ impl HourglassMeshBuilder {
         self
     }
 
+    /// Adds sand splash configuration to the hourglass
+    pub fn with_sand_splash(mut self, config: SandSplashConfig) -> Self {
+        self.sand_splash_config = Some(config);
+        self
+    }
+
     /// Builds the hourglass entity and all its configured components
     pub fn build(
         self,
@@ -202,6 +210,11 @@ impl HourglassMeshBuilder {
             }
 
             entity_commands.insert(hourglass);
+        }
+
+        // Add sand splash if configured
+        if let Some(sand_splash_config) = self.sand_splash_config {
+            entity_commands.insert(SandSplash::new(sand_splash_config));
         }
 
         let hourglass_entity = entity_commands.id();

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -3,7 +3,7 @@
 use crate::events::*;
 use crate::mesh_hourglass::{sync_mesh_hourglass_with_timer, update_mesh_hourglass_sand};
 use crate::resources::HourglassConfig;
-use crate::systems::update_hourglasses;
+use crate::systems::{update_hourglasses, update_sand_splash};
 use bevy::prelude::*;
 
 /// Plugin for adding hourglass functionality to Bevy apps
@@ -25,7 +25,12 @@ impl Plugin for HourglassPlugin {
         // Mesh-based visualization systems
         app.add_systems(
             Update,
-            (sync_mesh_hourglass_with_timer, update_mesh_hourglass_sand).chain(),
+            (
+                sync_mesh_hourglass_with_timer,
+                update_mesh_hourglass_sand,
+                update_sand_splash,
+            )
+                .chain(),
         );
     }
 }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1,8 +1,10 @@
 //! Systems for updating hourglass state.
 
-use crate::components::Hourglass;
+use crate::components::{Hourglass, SandSplash, SandSplashParticle};
 use crate::events::{HourglassEmptyEvent, HourglassFlipStartEvent};
 use bevy::prelude::*;
+use bevy::sprite::{AlphaMode2d, Mesh2d};
+use rand::prelude::*;
 
 /// System that updates all hourglasses
 pub fn update_hourglasses(
@@ -37,4 +39,101 @@ pub fn update_hourglasses(
             });
         }
     }
+}
+
+/// System that handles sand splash animation for mesh hourglasses
+pub fn update_sand_splash(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+    time: Res<Time>,
+    mut hourglass_query: Query<(Entity, &Hourglass, &mut SandSplash, &GlobalTransform)>,
+    mut particle_query: Query<(Entity, &mut SandSplashParticle)>,
+) {
+    let delta = time.delta_secs();
+
+    // Update existing splash particles
+    for (entity, mut particle) in particle_query.iter_mut() {
+        particle.lifetime -= delta;
+        if particle.lifetime <= 0.0 {
+            commands.entity(entity).despawn();
+        }
+    }
+
+    // Process hourglasses with sand splash
+    for (hourglass_entity, hourglass, mut sand_splash, global_transform) in
+        hourglass_query.iter_mut()
+    {
+        if !sand_splash.config.enabled {
+            continue;
+        }
+
+        let is_currently_flowing = hourglass.running && hourglass.upper_chamber > 0.0;
+
+        // Update spawn timer
+        sand_splash.spawn_timer -= delta;
+
+        // Check if sand is actively flowing and hitting the bottom
+        if is_currently_flowing
+            && sand_splash.spawn_timer <= 0.0
+            && hourglass.lower_chamber > 0.01
+        {
+            // Reset spawn timer
+            sand_splash.spawn_timer = sand_splash.config.spawn_interval;
+
+            // Calculate the impact point (bottom of the hourglass)
+            let hourglass_pos = global_transform.translation();
+            let impact_y = hourglass_pos.y - 80.0; // Approximate bottom of hourglass
+
+            // Spawn splash particles
+            for _ in 0..sand_splash.config.particle_count {
+                spawn_splash_particle(
+                    &mut commands,
+                    &mut meshes,
+                    &mut materials,
+                    Vec3::new(hourglass_pos.x, impact_y, hourglass_pos.z + 0.2),
+                    &sand_splash.config,
+                );
+            }
+        }
+
+        sand_splash.was_flowing = is_currently_flowing;
+    }
+}
+
+/// Spawns a single sand splash particle at the given position
+fn spawn_splash_particle(
+    commands: &mut Commands,
+    meshes: &mut ResMut<Assets<Mesh>>,
+    materials: &mut ResMut<Assets<ColorMaterial>>,
+    impact_position: Vec3,
+    config: &crate::components::SandSplashConfig,
+) {
+    let mut rng = thread_rng();
+
+    // Random offset within splash radius
+    let angle = rng.gen::<f32>() * 2.0 * std::f32::consts::PI;
+    let distance = rng.gen::<f32>() * config.splash_radius;
+    let offset_x = angle.cos() * distance;
+    let offset_y = rng.gen::<f32>() * 10.0 - 5.0; // Small vertical variation
+
+    let particle_position = impact_position + Vec3::new(offset_x, offset_y, 0.0);
+
+    // Create a simple rectangle mesh for the particle
+    let size = config.particle_size;
+    let mesh = meshes.add(Rectangle::new(size, size));
+    let material = materials.add(ColorMaterial {
+        color: config.particle_color,
+        alpha_mode: AlphaMode2d::Blend,
+        ..default()
+    });
+
+    commands.spawn((
+        SandSplashParticle {
+            lifetime: config.particle_duration,
+        },
+        Mesh2d(mesh),
+        MeshMaterial2d(material),
+        Transform::from_translation(particle_position),
+    ));
 }


### PR DESCRIPTION
This PR implements the optional sand splash animation feature requested in #31.

## Changes
- Add `SandSplashConfig` struct with configurable splash parameters
- Implement `SandSplash` and `SandSplashParticle` components
- Add `update_sand_splash` system for particle spawning and lifecycle
- Integrate sand splash into `HourglassMeshBuilder` with `with_sand_splash()` method
- Create `sand_splash_demo.rs` example showcasing the feature
- Add rand dependency for particle positioning

## Features
- Optional by default (no performance impact unless enabled)
- Highly configurable splash parameters
- Builder pattern integration
- Automatic particle lifecycle management
- Random particle positioning for natural effect

Closes #31

Generated with [Claude Code](https://claude.ai/code)